### PR TITLE
Refactor : 정규레시피 생성 과정 리팩토링

### DIFF
--- a/be/cocktail/src/main/java/com/BE/cocktail/ingredient/IngredientRequest.java
+++ b/be/cocktail/src/main/java/com/BE/cocktail/ingredient/IngredientRequest.java
@@ -1,0 +1,22 @@
+package com.BE.cocktail.ingredient;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class IngredientRequest {
+
+    private String name;
+
+    private String amount;
+
+    //test용 정적 팩토레 메서드
+    public static IngredientRequest of(String name, String amount) {
+        IngredientRequest response = new IngredientRequest(name, amount);
+
+        return response;
+    }
+
+}

--- a/be/cocktail/src/main/java/com/BE/cocktail/ingredient/IngredientResponses.java
+++ b/be/cocktail/src/main/java/com/BE/cocktail/ingredient/IngredientResponses.java
@@ -14,13 +14,14 @@ import java.util.stream.Collectors;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class IngredientResponses {
 
+    //RegularRecipeCreateResponseDto 생성시 그안에 ingredient부분이 재료리스트형태로 들어가야 하기 때문에 그것을 담당하는 클래스
     private String name;
 
     private String amount;
 
     public static IngredientResponses of(RegularRecipe regularRecipe) {
 
-        IngredientResponses response = new IngredientResponses(regularRecipe.getName(), regularRecipe.getAmount());
+        IngredientResponses response = new IngredientResponses(regularRecipe.getIngredient(), regularRecipe.getAmount());
 
         return response;
     }

--- a/be/cocktail/src/main/java/com/BE/cocktail/regularRecipe/RegularRecipe.java
+++ b/be/cocktail/src/main/java/com/BE/cocktail/regularRecipe/RegularRecipe.java
@@ -5,6 +5,8 @@ import lombok.*;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -20,7 +22,7 @@ public class RegularRecipe {
     @Column(nullable = false)
     private String imageUrl;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String name;
 
     private String description;
@@ -71,17 +73,34 @@ public class RegularRecipe {
         this.amount = amount;
     }
 
-    public static RegularRecipe of(RegularRecipeCreateDto createdto) {
-        RegularRecipe regularRecipe = new RegularRecipe(
-                createdto.getImageUrl(),
-                createdto.getName(),
-                createdto.getDescription(),
-                createdto.getRecipe(),
-                createdto.getAlcVol(),
-                createdto.getBaseAlc(),
-                createdto.getIngredient(),
-                createdto.getAmount()
-        );
+    public static List<RegularRecipe> listOf(RegularRecipeCreateDto createdto) {
+
+        List<RegularRecipe> regularRecipeList = new ArrayList<>();
+
+
+        createdto.getIngredientList().stream()
+                .forEach(ingredient -> {
+                                RegularRecipe regularRecipe = new RegularRecipe(
+                                        createdto.getImageUrl(),
+                                        createdto.getName(),
+                                        createdto.getDescription(),
+                                        createdto.getRecipe(),
+                                        createdto.getAlcVol(),
+                                        createdto.getBaseAlc(),
+                                        ingredient.getName(),
+                                        ingredient.getAmount() );
+
+                                regularRecipeList.add(regularRecipe);
+        });
+
+        return regularRecipeList;
+    }
+
+
+    //test용 정적 팩토리 메서드
+    public static RegularRecipe of(String imageUrl, String name, String description, String recipe, Integer alcVol, String baseAlc, String ingredient, String amount) {
+
+        RegularRecipe regularRecipe = new RegularRecipe(imageUrl, name, description, recipe, alcVol, baseAlc, ingredient, amount);
 
         return regularRecipe;
     }

--- a/be/cocktail/src/main/java/com/BE/cocktail/regularRecipe/RegularRecipeService.java
+++ b/be/cocktail/src/main/java/com/BE/cocktail/regularRecipe/RegularRecipeService.java
@@ -33,11 +33,14 @@ public class RegularRecipeService {
     @Transactional
     public RegularRecipeCreateResponseDto saveRegularRecipe(RegularRecipeCreateDto createdto) {
 
-        RegularRecipe regularRecipe = RegularRecipe.of(createdto);
+        List<RegularRecipe> regularRecipeList = RegularRecipe.listOf(createdto);
 
-        regularRecipeRepository.save(regularRecipe);
+        for (RegularRecipe regularRecipe:regularRecipeList) {
+            regularRecipeRepository.save(regularRecipe);
+        }
 
-        return RegularRecipeCreateResponseDto.of(regularRecipe);
+        return RegularRecipeCreateResponseDto.of(regularRecipeList);
+
     }
 
 }

--- a/be/cocktail/src/main/java/com/BE/cocktail/regularRecipe/dto/RegularRecipeCreateDto.java
+++ b/be/cocktail/src/main/java/com/BE/cocktail/regularRecipe/dto/RegularRecipeCreateDto.java
@@ -1,10 +1,14 @@
 package com.BE.cocktail.regularRecipe.dto;
 
+import com.BE.cocktail.ingredient.IngredientRequest;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class RegularRecipeCreateDto {
 
     private String name;
@@ -17,10 +21,17 @@ public class RegularRecipeCreateDto {
 
     private String baseAlc;
 
-    private String ingredient;
-
-    private String amount;
+    private List<IngredientRequest> ingredientList;
 
     private String imageUrl;
+
+    //test를 위한 정적팩토리메서드
+    public static RegularRecipeCreateDto of(String name, String description, String recipe, Integer alcVol, String baseAlc,
+                                            List<IngredientRequest> ingredientList, String imageUrl) {
+
+        RegularRecipeCreateDto createDto = new RegularRecipeCreateDto(name, description, recipe, alcVol, baseAlc, ingredientList, imageUrl);
+
+        return createDto;
+    }
 
 }

--- a/be/cocktail/src/main/java/com/BE/cocktail/regularRecipe/dto/RegularRecipeCreateResponseDto.java
+++ b/be/cocktail/src/main/java/com/BE/cocktail/regularRecipe/dto/RegularRecipeCreateResponseDto.java
@@ -1,12 +1,14 @@
 package com.BE.cocktail.regularRecipe.dto;
 
+import com.BE.cocktail.ingredient.IngredientRequest;
+import com.BE.cocktail.ingredient.IngredientResponses;
 import com.BE.cocktail.regularRecipe.RegularRecipe;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -20,28 +22,32 @@ public class RegularRecipeCreateResponseDto {
 
     private Integer alcVol;
 
-    private String ingredient;
+    private String baseAlc;
 
-    private String amount;
+    private List<IngredientResponses> ingredient;
 
     private String imageUrl;
 
     private LocalDateTime createdAt;
 
-    public static RegularRecipeCreateResponseDto of(RegularRecipe regularRecipe) {
 
-        RegularRecipeCreateResponseDto response = new RegularRecipeCreateResponseDto(
-                regularRecipe.getName(),
-                regularRecipe.getDescription(),
-                regularRecipe.getRecipe(),
-                regularRecipe.getAlcVol(),
-                regularRecipe.getIngredient(),
-                regularRecipe.getAmount(),
-                regularRecipe.getImageUrl(),
-                regularRecipe.getCreatedAt()
-        );
+    public static RegularRecipeCreateResponseDto of(List<RegularRecipe> regularRecipeList) {
 
-        return response;
+        List<IngredientResponses> ingredient = IngredientResponses.listOf(regularRecipeList);
+
+        RegularRecipeCreateResponseDto responseDto =
+                new RegularRecipeCreateResponseDto(
+                        regularRecipeList.get(0).getName(),
+                        regularRecipeList.get(0).getDescription(),
+                        regularRecipeList.get(0).getRecipe(),
+                        regularRecipeList.get(0).getAlcVol(),
+                        regularRecipeList.get(0).getBaseAlc(),
+                        ingredient,
+                        regularRecipeList.get(0).getImageUrl(),
+                        regularRecipeList.get(0).getCreatedAt()
+                );
+
+        return responseDto;
     }
 
 }


### PR DESCRIPTION
### PR 타입

-[ ] 기능 추가
-[ ] 기능 삭제
-[O] 코드 리팩토링
-[ ] 버그 수정
-[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 정규레시피 생성 요청시 오는 요청 바디에 ingredient가 리스트형태일 경우 리스트 안에 있는 데이터마다 각각 엔티티가 생성되고 응답할 때는 다시 ingredient를 하나로 합쳐서 응답


### 테스트 결과
- 데이터베이스에 재료별로 데이터가 생성되어야함 또한 응답시에는 ingredient가 리스트 형태로 응답