### PR TITLE
Refactor : 페이지 분리 및 애니메이션, type 이름 변경

### DIFF
--- a/fe/src/App.tsx
+++ b/fe/src/App.tsx
@@ -7,6 +7,8 @@ import Signup from "./pages/Signup";
 import DetailPage from "./pages/DetailPage";
 import CocktailRegistration from "./pages/CocktailRegistration";
 import Error from "./pages/Error";
+import CustomRecipes from "./pages/CustomRecipes";
+import SearchResults from "./pages/SearchResults";
 
 function App() {
   return (
@@ -15,8 +17,8 @@ function App() {
       <Routes>
         <Route element={<Layout />}>
           <Route path="/" element={<Main />} />
-          <Route path="/custom" element={<Main />} />
-          <Route path="/search" element={<Main />} />
+          <Route path="/custom" element={<CustomRecipes />} />
+          <Route path="/search" element={<SearchResults />} />
           <Route path="/detail" element={<DetailPage />} />
           <Route path="/registration" element={<CocktailRegistration />} />
         </Route>

--- a/fe/src/components/card/Card.tsx
+++ b/fe/src/components/card/Card.tsx
@@ -7,22 +7,12 @@ interface CardProps {
   description: string;
 }
 const Card = ({ title, image, description }: CardProps) => {
-  const descriptions = description.split("\n").reverse();
   const navigate = useNavigate();
   return (
     <Container onClick={() => navigate("/detail")}>
       <Image>
-        {descriptions.map((e, i) => (
-          <HiddenText
-            key={i}
-            className="hidden-text"
-            line={i}
-            leng={descriptions.length}
-          >
-            {e}
-          </HiddenText>
-        ))}
-      </Image>{" "}
+        <HiddenText className="hidden-text">{description}</HiddenText>
+      </Image>
       {/*url={image}*/}
       <Menuname>{title}</Menuname>
     </Container>
@@ -43,46 +33,35 @@ const Container = styled.div`
   box-sizing: border-box;
 `;
 
-interface Url {
-  url: string;
-}
-
 const Image = styled.div`
   flex: 5;
   width: 13rem;
-  /* display: flex;
-  align-items: center;
-  justify-content: center; */
-  background-image: url(${cocktail});
+  display: flex;
+  align-items: end;
+  justify-content: center;
+  background: url(${cocktail});
   background-size: cover;
   background-position: center;
   border-radius: 15px 15px 0 0;
   position: relative;
   overflow: hidden;
   &:hover {
+    background-image: linear-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2)),
+      url(${cocktail});
     > .hidden-text {
-      right: 0;
-      margin: 2px 10px;
+      opacity: 1;
     }
   }
 `;
 
-interface LineNumber {
-  line: number;
-  leng: number;
-}
-
 const HiddenText = styled.p`
   font-size: 1.1rem;
   font-weight: bold;
+  opacity: 0;
   color: white;
-  margin: 2px 10px;
-  position: absolute;
-  bottom: ${(props: LineNumber) => props.line * 2.5 + 1}rem;
-  right: -300%;
+  margin: 5px;
   text-align: end;
-  transition: right 0.35s
-    ${(props: LineNumber) => Math.abs(props.line - props.leng) * 0.2}s;
+  transition: all 0.35s;
 `;
 
 const Menuname = styled.div`

--- a/fe/src/components/card/CardList.tsx
+++ b/fe/src/components/card/CardList.tsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import { useState } from "react";
 import { GrPrevious, GrNext } from "react-icons/gr";
 import Card from "./Card";
-import type { recipeCard } from "../../redux/slices/RecipeSlice";
+import { RecipeCard } from "../../redux/slices/RecipeSlice";
 
 const CardsContainer = styled.div`
   width: 100%;
@@ -70,7 +70,7 @@ const CardsPageNationButton = styled.button`
 `;
 
 interface ListProps {
-  list: recipeCard[];
+  list: RecipeCard[];
   category: string;
   isSearch?: boolean;
 }

--- a/fe/src/pages/CustomRecipes.tsx
+++ b/fe/src/pages/CustomRecipes.tsx
@@ -1,0 +1,72 @@
+import styled from "styled-components";
+import { RecipesContainer } from "./Main";
+import { Link } from "react-router-dom";
+import { useEffect } from "react";
+import { update } from "../redux/slices/RecipeSlice";
+import { useAppSelector, useAppDispatch } from "../redux/hooks";
+import Card from "../components/card/Card";
+import axios from "axios";
+const CustomGuide = styled.div`
+  display: flex;
+`;
+
+const RegistrationLink = styled(Link)`
+  text-decoration-line: none;
+  color: white;
+  background-color: #96a5ff;
+  font-weight: bold;
+  font-size: 1.2rem;
+  padding: 5px 3px;
+  border-radius: 5px;
+  &:hover {
+    cursor: pointer;
+    background-color: #5469de;
+  }
+`;
+
+const GuideText = styled.div`
+  width: max-content;
+  padding: 5px 10px;
+  font-weight: bold;
+  font-size: 1.2rem;
+`;
+
+const CardsRow = styled.div`
+  margin: 20px 0;
+  padding-bottom: 30px;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  grid-gap: 30px;
+  place-items: center;
+`;
+
+export default function CustomRecipes() {
+  const recipeCards = useAppSelector((state) => state.recipeList.recipes);
+  const dispatch = useAppDispatch();
+  useEffect(() => {
+    axios.get(`http://localhost:4000/custom`).then((res) => {
+      dispatch(update(res.data));
+    });
+  }, []);
+  return (
+    <RecipesContainer>
+      <CustomGuide>
+        <GuideText>커스텀 레시피</GuideText>
+        <RegistrationLink to={"/upload"}>레시피 등록하기</RegistrationLink>
+      </CustomGuide>
+      <CardsRow>
+        {recipeCards.list &&
+          recipeCards.list.map((recipe, i) => {
+            return (
+              <Card
+                key={i}
+                title={recipe.title}
+                image={recipe.image}
+                description={recipe.description}
+              />
+            );
+          })}
+      </CardsRow>
+    </RecipesContainer>
+  );
+}

--- a/fe/src/pages/Main.tsx
+++ b/fe/src/pages/Main.tsx
@@ -1,39 +1,17 @@
 import styled from "styled-components";
-import Card from "../components/card/Card";
-import { useLocation, useSearchParams } from "react-router-dom";
-import { Link } from "react-router-dom";
 import CardList from "../components/card/CardList";
 import { useAppDispatch, useAppSelector } from "../redux/hooks";
 import { useEffect } from "react";
 import axios from "axios";
-import { upDate } from "../redux/slices/RecipeSlice";
-import type { recipeCard } from "../redux/slices/RecipeSlice";
+import { update } from "../redux/slices/RecipeSlice";
 
-const RecipesContainer = styled.div`
+export const RecipesContainer = styled.div`
   min-height: 100vh;
   height: 100%;
   width: 1360px;
   margin: 85px auto 0;
   position: relative;
   padding: 60px 0 20px;
-`;
-
-const CustomGuide = styled.div`
-  display: flex;
-`;
-
-const RegistrationLink = styled(Link)`
-  text-decoration-line: none;
-  color: white;
-  background-color: #96a5ff;
-  font-weight: bold;
-  font-size: 1.2rem;
-  padding: 5px 3px;
-  border-radius: 5px;
-  &:hover {
-    cursor: pointer;
-    background-color: #5469de;
-  }
 `;
 
 const GuideText = styled.div`
@@ -43,109 +21,24 @@ const GuideText = styled.div`
   font-size: 1.2rem;
 `;
 
-const CardsRow = styled.div`
-  margin: 20px 0;
-  padding-bottom: 30px;
-  display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  grid-gap: 30px;
-  place-items: center;
-`;
-
 export default function Main() {
-  const pathName = useLocation().pathname;
-  console.log(pathName);
-
   const dispatch = useAppDispatch();
   const recipeList = useAppSelector((state) => state.recipeList.recipes);
-  const [searchParams, setSearchParams] = useSearchParams();
-  const searchValue = searchParams.get("value") ?? "";
+
   useEffect(() => {
-    let path: string;
-    switch (pathName) {
-      case "/custom":
-        path = "custom";
-        break;
-      case "/search":
-        path = "searched";
-        break;
-      default:
-        path = "regular";
-        break;
-    }
-    axios.get(`http://localhost:4000/${path}`).then((res) => {
-      const data =
-        path === "searched"
-          ? {
-              regular: res.data.regular.filter(
-                (e: recipeCard) =>
-                  e.ingredient.includes(searchValue) ||
-                  e.title.includes(searchValue),
-              ),
-              custom: res.data.custom.filter(
-                (e: recipeCard) =>
-                  e.ingredient.includes(searchValue) ||
-                  e.title.includes(searchValue),
-              ),
-            }
-          : res.data;
-      dispatch(upDate(data));
+    axios.get(`http://localhost:4000/regular`).then((res) => {
+      dispatch(update(res.data));
     });
-  }, [pathName, searchValue]);
+  }, []);
   return (
     <>
       <RecipesContainer>
-        {pathName === "/custom" ? (
-          <>
-            <CustomGuide>
-              <GuideText>커스텀 레시피</GuideText>
-              <RegistrationLink to={"/upload"}>
-                레시피 등록하기
-              </RegistrationLink>
-            </CustomGuide>
-            <CardsRow>
-              {recipeList.list &&
-                recipeList.list.map((recipe, i) => {
-                  return (
-                    <Card
-                      key={i}
-                      title={recipe.title}
-                      image={recipe.image}
-                      description={recipe.description}
-                    />
-                  );
-                })}
-            </CardsRow>
-          </>
-        ) : pathName === "/search" ? (
-          <>
-            {Object.keys(recipeList).map((key: string, i) => {
-              return (
-                recipeList[key].length !== 0 && (
-                  <CardList
-                    list={recipeList[key]}
-                    category={key}
-                    key={i}
-                    isSearch={pathName === "/search"}
-                  />
-                )
-              );
-            })}
-          </>
-        ) : (
-          <>
-            <GuideText>정규 레시피</GuideText>
-            {Object.keys(recipeList).map((key: string, i) => {
-              return (
-                <CardList
-                  list={recipeList[key]}
-                  category={key.slice(-1)}
-                  key={i}
-                />
-              );
-            })}
-          </>
-        )}
+        <GuideText>정규 레시피</GuideText>
+        {Object.keys(recipeList).map((key: string, i) => {
+          return (
+            <CardList list={recipeList[key]} category={key.slice(-1)} key={i} />
+          );
+        })}
       </RecipesContainer>
     </>
   );

--- a/fe/src/pages/SearchResults.tsx
+++ b/fe/src/pages/SearchResults.tsx
@@ -1,0 +1,45 @@
+import { RecipesContainer } from "./Main";
+import CardList from "../components/card/CardList";
+import axios from "axios";
+import { useAppDispatch, useAppSelector } from "../redux/hooks";
+import { RecipeCard, update } from "../redux/slices/RecipeSlice";
+import { useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
+
+export default function SearchResults() {
+  const dispatch = useAppDispatch();
+  const recipeCards = useAppSelector((state) => state.recipeList.recipes);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const searchValue = searchParams.get("value") ?? "";
+  useEffect(() => {
+    axios.get(`http://localhost:4000/searched`).then((res) => {
+      const data = {
+        regular: res.data.regular.filter(
+          (e: RecipeCard) =>
+            e.ingredient.includes(searchValue) || e.title.includes(searchValue),
+        ),
+        custom: res.data.custom.filter(
+          (e: RecipeCard) =>
+            e.ingredient.includes(searchValue) || e.title.includes(searchValue),
+        ),
+      };
+      dispatch(update(data));
+    });
+  }, [searchValue]);
+  return (
+    <RecipesContainer>
+      {Object.keys(recipeCards).map((key: string, i) => {
+        return (
+          recipeCards[key].length !== 0 && (
+            <CardList
+              list={recipeCards[key]}
+              category={key}
+              key={i}
+              isSearch={true}
+            />
+          )
+        );
+      })}
+    </RecipesContainer>
+  );
+}

--- a/fe/src/redux/slices/RecipeSlice.ts
+++ b/fe/src/redux/slices/RecipeSlice.ts
@@ -1,9 +1,9 @@
 import { createSlice } from "@reduxjs/toolkit";
 
 export interface Recipes {
-  recipes: { [key: string]: recipeCard[] };
+  recipes: { [key: string]: RecipeCard[] };
 }
-export interface recipeCard {
+export interface RecipeCard {
   title: string;
   image: string;
   description: string;
@@ -27,11 +27,11 @@ const recipeListSlice = createSlice({
   name: "recipes",
   initialState: initialState,
   reducers: {
-    upDate: (state, action) => {
+    update: (state, action) => {
       state.recipes = action.payload;
     },
   },
 });
 
 export default recipeListSlice.reducer;
-export const { upDate } = recipeListSlice.actions;
+export const { update } = recipeListSlice.actions;


### PR DESCRIPTION
### PR 타입
-[ ] 기능 추가
-[ ] 기능 삭제
-[o] 코드 리팩토링
-[ ] 버그 수정
-[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- main 페이지 컴포넌트 분리
- card hover 애니메이션 변겅
- slice type 이름 변경

### 테스트 결과
- card 호버 시 오른 쪽에서 등장하던 description 중앙으로 고정
- main 페이지 컴포넌트를 Main, CustomRecipes, SearchResults 페이지 컴포넌트로 분리
- interface recipeCard => interface RecipeCard 로 이름 변경