### PR TITLE
Refactor : 정규 레시피 전체 조회 순서 적용, ApiResponse 적용

### DIFF
--- a/be/cocktail/src/main/java/com/BE/cocktail/controller/regularRecipe/RegularRecipeController.java
+++ b/be/cocktail/src/main/java/com/BE/cocktail/controller/regularRecipe/RegularRecipeController.java
@@ -3,6 +3,7 @@ package com.BE.cocktail.controller.regularRecipe;
 import com.BE.cocktail.dto.apiResponse.ApiResponse;
 import com.BE.cocktail.dto.regularRecipe.RegularRecipeGetResponseDto;
 
+import com.BE.cocktail.dto.regularRecipe.RegularRecipeMultiResponseDto;
 import com.BE.cocktail.service.regularRecipe.RegularRecipeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,5 +23,14 @@ public class RegularRecipeController {
 
         return ApiResponse.ok(response);
     }
+
+    @GetMapping(value = "/regular/findAll")
+    public ApiResponse<RegularRecipeMultiResponseDto> findAllRegularRecipes() {
+
+        RegularRecipeMultiResponseDto responseDto = regularRecipeService.findAllRecipes();
+
+        return ApiResponse.ok(responseDto);
+    }
+
 
 }

--- a/be/cocktail/src/main/java/com/BE/cocktail/dto/regularRecipe/RegularRecipeMultiResponseDto.java
+++ b/be/cocktail/src/main/java/com/BE/cocktail/dto/regularRecipe/RegularRecipeMultiResponseDto.java
@@ -14,7 +14,7 @@ public class RegularRecipeMultiResponseDto {
     private Map<String, List<MultiResponse>> response;
 
     public RegularRecipeMultiResponseDto() {
-        this.response = new LinkedHashMap<>();
+        this.response = new TreeMap<>();
     }
 
     public static RegularRecipeMultiResponseDto of(List<RegularRecipe> regularRecipes) {

--- a/be/cocktail/src/main/java/com/BE/cocktail/service/regularRecipe/RegularRecipeService.java
+++ b/be/cocktail/src/main/java/com/BE/cocktail/service/regularRecipe/RegularRecipeService.java
@@ -1,14 +1,17 @@
 package com.BE.cocktail.service.regularRecipe;
 
+import com.BE.cocktail.dto.apiResponse.ApiResponse;
 import com.BE.cocktail.dto.apiResponse.CocktailRtnConsts;
 import com.BE.cocktail.dto.regularRecipe.RegularRecipeGetResponseDto;
 
+import com.BE.cocktail.dto.regularRecipe.RegularRecipeMultiResponseDto;
 import com.BE.cocktail.exception.CocktailException;
 import com.BE.cocktail.persistence.domain.regularRecipe.RegularRecipe;
 import com.BE.cocktail.persistence.repository.regularRecipe.RegularRecipeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
 
 import java.util.*;
 
@@ -24,6 +27,11 @@ public class RegularRecipeService {
                 .orElseThrow(() -> new CocktailException(CocktailRtnConsts.ERR400));
 
         return RegularRecipeGetResponseDto.of(regularRecipe);
+    }
+    @Transactional(readOnly = true)
+    public RegularRecipeMultiResponseDto findAllRecipes() {
+        List<RegularRecipe> regularRecipes = regularRecipeRepository.findAll();
+        return RegularRecipeMultiResponseDto.of(regularRecipes);
     }
 
 }


### PR DESCRIPTION
### PR 타입

-[0] 기능 추가
-[] 기능 삭제
-[0] 코드 리팩토링
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
응답 메세지 순서를 위해 LinkedHashMap -> TreeMap 변경
ResponseEntity ->  ApiResponse  응답 메시지 적용

### 테스트 결과
포스트맨에서 순서 적용 및 알코올 도수 끼리 그룹화 성공 및 응답 메시지 성공