### PR TITLE
Feat : 정규레시피 페이징 기능 구현

### DIFF
--- a/be/cocktail/src/main/java/com/BE/cocktail/controller/customeRecipe/CustomRecipeController.java
+++ b/be/cocktail/src/main/java/com/BE/cocktail/controller/customeRecipe/CustomRecipeController.java
@@ -1,6 +1,7 @@
 package com.BE.cocktail.controller.customeRecipe;
 
 import com.BE.cocktail.dto.apiResponse.ApiResponse;
+import com.BE.cocktail.dto.utils.MultiResponseDto;
 import com.BE.cocktail.service.customRecipe.CustomRecipeService;
 import com.BE.cocktail.dto.customRecipe.CustomPatchDto;
 import com.BE.cocktail.dto.customRecipe.CustomRecipePostDto;
@@ -32,6 +33,14 @@ public class CustomRecipeController {
         CustomRecipeResponseDtoList customRecipeResponseDtoList = customRecipeService.findCustomRecipeList();
 
         return ApiResponse.ok(customRecipeResponseDtoList);
+    }
+
+    @GetMapping("/find")
+    public ApiResponse<MultiResponseDto<CustomRecipeResponseDto>> getCustomRecipePaging(@RequestParam int page, @RequestParam int size) {
+
+        MultiResponseDto<CustomRecipeResponseDto> responseDto = customRecipeService.paging(page - 1, size);
+
+        return ApiResponse.ok(responseDto);
     }
 
 

--- a/be/cocktail/src/main/java/com/BE/cocktail/dto/utils/MultiResponseDto.java
+++ b/be/cocktail/src/main/java/com/BE/cocktail/dto/utils/MultiResponseDto.java
@@ -1,0 +1,25 @@
+package com.BE.cocktail.dto.utils;
+
+import jdk.dynalink.beans.StaticClass;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MultiResponseDto<T> {
+
+    private List<T> data;
+
+    private PageInfo pageInfo;
+
+    public static <T> MultiResponseDto<T> of(List<T> data, PageInfo pageInfo) {
+
+        MultiResponseDto<T> multiResponseDto = new MultiResponseDto(data, pageInfo);
+
+        return multiResponseDto;
+    }
+
+}

--- a/be/cocktail/src/main/java/com/BE/cocktail/dto/utils/PageInfo.java
+++ b/be/cocktail/src/main/java/com/BE/cocktail/dto/utils/PageInfo.java
@@ -1,0 +1,29 @@
+package com.BE.cocktail.dto.utils;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.awt.print.Pageable;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PageInfo {
+
+    private int page;
+
+    private int size;
+
+    private int totalPage;
+
+    private long totalSize;
+
+    public static <T> PageInfo of(Page<T> page) {
+
+        PageInfo pageInfo = new PageInfo(page.getNumber() + 1, page.getSize(), page.getTotalPages(), page.getTotalElements());
+
+        return pageInfo;
+    }
+
+}

--- a/be/cocktail/src/main/java/com/BE/cocktail/service/customRecipe/CustomRecipeService.java
+++ b/be/cocktail/src/main/java/com/BE/cocktail/service/customRecipe/CustomRecipeService.java
@@ -1,6 +1,8 @@
 package com.BE.cocktail.service.customRecipe;
 
 import com.BE.cocktail.dto.apiResponse.CocktailRtnConsts;
+import com.BE.cocktail.dto.utils.MultiResponseDto;
+import com.BE.cocktail.dto.utils.PageInfo;
 import com.BE.cocktail.persistence.domain.customRecipe.CustomRecipe;
 import com.BE.cocktail.persistence.repository.customRecipe.CustomRecipeRepository;
 import com.BE.cocktail.dto.customRecipe.CustomPatchDto;
@@ -9,6 +11,9 @@ import com.BE.cocktail.dto.customRecipe.CustomRecipeResponseDto;
 import com.BE.cocktail.dto.customRecipe.CustomRecipeResponseDtoList;
 import com.BE.cocktail.exception.CocktailException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -88,4 +93,11 @@ public class CustomRecipeService {
     }
 
 
+    public MultiResponseDto<CustomRecipeResponseDto> paging(int page, int size) {
+
+        Page<CustomRecipe> pages = customRecipeRepository.findAll(PageRequest.of(page, size, Sort.by("id").descending()));
+        List<CustomRecipe> customRecipes = pages.getContent();
+
+        return MultiResponseDto.of(CustomRecipeResponseDtoList.of(customRecipes).getCustomRecipeResponseDtoList(), PageInfo.of(pages));
+    }
 }


### PR DESCRIPTION
### PR 타입

-[O] 기능 추가
-[ ] 기능 삭제
-[ ] 코드 리팩토링
-[ ] 버그 수정
-[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 정규레시피 개수와 페이지번호를 요청하면 페이징하여 응답

### 테스트 결과
- 응답바디가 페이징되어서 출력되야한다 또한 pageInfo도 들어가있어야한다