### PR TITLE
Feat : 커스텀레시피 검색기능 구현

### DIFF
--- a/be/cocktail/src/main/java/com/BE/cocktail/controller/customeRecipe/CustomRecipeController.java
+++ b/be/cocktail/src/main/java/com/BE/cocktail/controller/customeRecipe/CustomRecipeController.java
@@ -1,12 +1,9 @@
 package com.BE.cocktail.controller.customeRecipe;
 
 import com.BE.cocktail.dto.apiResponse.ApiResponse;
+import com.BE.cocktail.dto.customRecipe.*;
 import com.BE.cocktail.dto.utils.MultiResponseDto;
 import com.BE.cocktail.service.customRecipe.CustomRecipeService;
-import com.BE.cocktail.dto.customRecipe.CustomPatchDto;
-import com.BE.cocktail.dto.customRecipe.CustomRecipePostDto;
-import com.BE.cocktail.dto.customRecipe.CustomRecipeResponseDto;
-import com.BE.cocktail.dto.customRecipe.CustomRecipeResponseDtoList;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -35,6 +32,15 @@ public class CustomRecipeController {
         return ApiResponse.ok(customRecipeResponseDtoList);
     }
 
+    @GetMapping("/search/{keyword}")
+    public ApiResponse<MultiResponseDto<CustomSearchResponseDto>> getSearchPaging(@PathVariable("keyword") String keyword,
+                                                                                  @RequestParam int page,
+                                                                                  @RequestParam int size) {
+
+        MultiResponseDto<CustomSearchResponseDto> responseDto = customRecipeService.searchPaging(keyword, page - 1, size);
+
+        return ApiResponse.ok(responseDto);
+    }
     @GetMapping("/find")
     public ApiResponse<MultiResponseDto<CustomRecipeResponseDto>> getCustomRecipePaging(@RequestParam int page, @RequestParam int size) {
 

--- a/be/cocktail/src/main/java/com/BE/cocktail/dto/customRecipe/CustomSearchResponseDto.java
+++ b/be/cocktail/src/main/java/com/BE/cocktail/dto/customRecipe/CustomSearchResponseDto.java
@@ -1,0 +1,37 @@
+package com.BE.cocktail.dto.customRecipe;
+
+import com.BE.cocktail.persistence.domain.customRecipe.CustomRecipe;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CustomSearchResponseDto {
+
+    private String name;
+
+    private String imageUrl;
+
+    private String ingredient;
+
+    public static CustomSearchResponseDto of(CustomRecipe recipe) {
+
+        CustomSearchResponseDto response = new CustomSearchResponseDto(recipe.getName(), recipe.getImageUrl(), recipe.getIngredient());
+
+        return response;
+    }
+
+    public static List<CustomSearchResponseDto> listOf(List<CustomRecipe> customRecipes) {
+
+        List<CustomSearchResponseDto> list = customRecipes.stream().map(CustomSearchResponseDto::of).collect(Collectors.toList());
+
+        return list;
+    }
+
+
+
+}

--- a/be/cocktail/src/main/java/com/BE/cocktail/persistence/repository/customRecipe/CustomRecipeRepository.java
+++ b/be/cocktail/src/main/java/com/BE/cocktail/persistence/repository/customRecipe/CustomRecipeRepository.java
@@ -1,11 +1,18 @@
 package com.BE.cocktail.persistence.repository.customRecipe;
 
 import com.BE.cocktail.persistence.domain.customRecipe.CustomRecipe;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
 import java.util.List;
 
 public interface CustomRecipeRepository extends JpaRepository<CustomRecipe, Long> {
 
 //    CustomRecipe findByName(String name);
     List<CustomRecipe> findByDeletedFalse();
+
+    @Query("SELECT c FROM CustomRecipe c WHERE (c.name LIKE %:keyword% OR c.ingredient LIKE %:keyword%)")
+    Page<CustomRecipe> findAllbyKeyword(String keyword, PageRequest id);
 }

--- a/be/cocktail/src/main/java/com/BE/cocktail/service/customRecipe/CustomRecipeService.java
+++ b/be/cocktail/src/main/java/com/BE/cocktail/service/customRecipe/CustomRecipeService.java
@@ -1,14 +1,11 @@
 package com.BE.cocktail.service.customRecipe;
 
 import com.BE.cocktail.dto.apiResponse.CocktailRtnConsts;
+import com.BE.cocktail.dto.customRecipe.*;
 import com.BE.cocktail.dto.utils.MultiResponseDto;
 import com.BE.cocktail.dto.utils.PageInfo;
 import com.BE.cocktail.persistence.domain.customRecipe.CustomRecipe;
 import com.BE.cocktail.persistence.repository.customRecipe.CustomRecipeRepository;
-import com.BE.cocktail.dto.customRecipe.CustomPatchDto;
-import com.BE.cocktail.dto.customRecipe.CustomRecipePostDto;
-import com.BE.cocktail.dto.customRecipe.CustomRecipeResponseDto;
-import com.BE.cocktail.dto.customRecipe.CustomRecipeResponseDtoList;
 import com.BE.cocktail.exception.CocktailException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -99,5 +96,12 @@ public class CustomRecipeService {
         List<CustomRecipe> customRecipes = pages.getContent();
 
         return MultiResponseDto.of(CustomRecipeResponseDtoList.of(customRecipes).getCustomRecipeResponseDtoList(), PageInfo.of(pages));
+    }
+
+    public MultiResponseDto<CustomSearchResponseDto> searchPaging(String keyword, int page, int size) {
+        Page<CustomRecipe> pages = customRecipeRepository.findAllbyKeyword(keyword, PageRequest.of(page, size, Sort.by("id").descending()));
+        List<CustomRecipe> customRecipes = pages.getContent();
+
+        return MultiResponseDto.of(CustomSearchResponseDto.listOf(customRecipes), PageInfo.of(pages));
     }
 }


### PR DESCRIPTION
### PR 타입

-[O] 기능 추가
-[ ] 기능 삭제
-[ ] 코드 리팩토링
-[ ] 버그 수정
-[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 커스텀레시피를 검색하면 페이징으로 응답

### 테스트 결과
- 키워드로 요청하면 해당하는 칵테일 이름 혹은 재료가 있는 칵테일 레시피가 페이징형태로 응답되어야함