### PR TITLE
Feat : 정규레시피 검색기능 구현

### DIFF
--- a/be/cocktail/src/main/java/com/BE/cocktail/controller/regularRecipe/RegularRecipeController.java
+++ b/be/cocktail/src/main/java/com/BE/cocktail/controller/regularRecipe/RegularRecipeController.java
@@ -1,9 +1,12 @@
 package com.BE.cocktail.controller.regularRecipe;
 
 import com.BE.cocktail.dto.apiResponse.ApiResponse;
+import com.BE.cocktail.dto.customRecipe.CustomSearchResponseDto;
 import com.BE.cocktail.dto.regularRecipe.RegularRecipeGetResponseDto;
 
 import com.BE.cocktail.dto.regularRecipe.RegularRecipeMultiResponseDto;
+import com.BE.cocktail.dto.regularRecipe.RegularSearchResponseDto;
+import com.BE.cocktail.dto.utils.MultiResponseDto;
 import com.BE.cocktail.service.regularRecipe.RegularRecipeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -11,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/regular")
 public class RegularRecipeController {
 
     private final RegularRecipeService regularRecipeService;
@@ -24,10 +28,20 @@ public class RegularRecipeController {
         return ApiResponse.ok(response);
     }
 
-    @GetMapping(value = "/regular/findAll")
+    @GetMapping(value = "/findAll")
     public ApiResponse<RegularRecipeMultiResponseDto> findAllRegularRecipes() {
 
         RegularRecipeMultiResponseDto responseDto = regularRecipeService.findAllRecipes();
+
+        return ApiResponse.ok(responseDto);
+    }
+
+    @GetMapping("/search/{keyword}")
+    public ApiResponse<MultiResponseDto<RegularSearchResponseDto>> getSearchPaging(@PathVariable("keyword") String keyword,
+                                                                                   @RequestParam int page,
+                                                                                   @RequestParam int size) {
+
+        MultiResponseDto<RegularSearchResponseDto> responseDto = regularRecipeService.searchPaging(keyword, page - 1, size);
 
         return ApiResponse.ok(responseDto);
     }

--- a/be/cocktail/src/main/java/com/BE/cocktail/dto/regularRecipe/RegularSearchResponseDto.java
+++ b/be/cocktail/src/main/java/com/BE/cocktail/dto/regularRecipe/RegularSearchResponseDto.java
@@ -1,0 +1,38 @@
+package com.BE.cocktail.dto.regularRecipe;
+
+import com.BE.cocktail.persistence.domain.regularRecipe.RegularRecipe;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RegularSearchResponseDto {
+
+
+    private String name;
+
+    private String imageUrl;
+
+    private String ingredient;
+
+    public static RegularSearchResponseDto of(RegularRecipe recipe) {
+
+        RegularSearchResponseDto response = new RegularSearchResponseDto(recipe.getName(), recipe.getImageUrl(), recipe.getIngredient());
+
+        return response;
+    }
+
+    public static List<RegularSearchResponseDto> listOf(List<RegularRecipe> recipes) {
+
+        List<RegularSearchResponseDto> list = recipes.stream().map(RegularSearchResponseDto::of).collect(Collectors.toList());
+
+        return list;
+    }
+
+
+
+}

--- a/be/cocktail/src/main/java/com/BE/cocktail/persistence/repository/regularRecipe/RegularRecipeRepository.java
+++ b/be/cocktail/src/main/java/com/BE/cocktail/persistence/repository/regularRecipe/RegularRecipeRepository.java
@@ -1,12 +1,19 @@
 package com.BE.cocktail.persistence.repository.regularRecipe;
 
 
+import com.BE.cocktail.dto.regularRecipe.RegularSearchResponseDto;
 import com.BE.cocktail.persistence.domain.regularRecipe.RegularRecipe;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
 import java.util.List;
 
 public interface RegularRecipeRepository extends JpaRepository<RegularRecipe, Long> {
 
     List<RegularRecipe> findAllByName(String name);
 
+    @Query("SELECT r FROM RegularRecipe r WHERE (r.name LIKE %:keyword% OR r.ingredient LIKE %:keyword%)")
+    Page<RegularRecipe> findAllByKeyword(String keyword, PageRequest id);
 }

--- a/be/cocktail/src/main/java/com/BE/cocktail/service/regularRecipe/RegularRecipeService.java
+++ b/be/cocktail/src/main/java/com/BE/cocktail/service/regularRecipe/RegularRecipeService.java
@@ -2,13 +2,21 @@ package com.BE.cocktail.service.regularRecipe;
 
 import com.BE.cocktail.dto.apiResponse.ApiResponse;
 import com.BE.cocktail.dto.apiResponse.CocktailRtnConsts;
+import com.BE.cocktail.dto.customRecipe.CustomSearchResponseDto;
 import com.BE.cocktail.dto.regularRecipe.RegularRecipeGetResponseDto;
 
 import com.BE.cocktail.dto.regularRecipe.RegularRecipeMultiResponseDto;
+import com.BE.cocktail.dto.regularRecipe.RegularSearchResponseDto;
+import com.BE.cocktail.dto.utils.MultiResponseDto;
+import com.BE.cocktail.dto.utils.PageInfo;
 import com.BE.cocktail.exception.CocktailException;
+import com.BE.cocktail.persistence.domain.customRecipe.CustomRecipe;
 import com.BE.cocktail.persistence.domain.regularRecipe.RegularRecipe;
 import com.BE.cocktail.persistence.repository.regularRecipe.RegularRecipeRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -34,4 +42,11 @@ public class RegularRecipeService {
         return RegularRecipeMultiResponseDto.of(regularRecipes);
     }
 
+    public MultiResponseDto<RegularSearchResponseDto> searchPaging(String keyword, int page, int size) {
+
+        Page<RegularRecipe> pages = regularRecipeRepository.findAllByKeyword(keyword, PageRequest.of(page, size, Sort.by("id").descending()));
+        List<RegularRecipe> responses = pages.getContent();
+
+        return MultiResponseDto.of(RegularSearchResponseDto.listOf(responses), PageInfo.of(pages));
+    }
 }


### PR DESCRIPTION
### PR 타입
-[O] 기능 추가
-[ ] 기능 삭제
-[ ] 코드 리팩토링
-[ ] 버그 수정
-[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 정규레시피를 검색하면 페이징으로 응답

### 테스트 결과
- 키워드를 가지고 정규레시피를 검색하면 레시피의 이름이나 재료에 이름이 같거나 글자가 포함된다면 그에 해당하는 데이터들이 페이징되어서 응답되어야함
