### PR TITLE
Refactor: CocktailRegistration페이지 서버로 전송할 재료 데이터 및 재료입력 폼 로직 수정

### DIFF
--- a/fe/package.json
+++ b/fe/package.json
@@ -59,5 +59,6 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.32.2",
     "prettier": "^2.8.8"
-  }
+  },
+  "proxy": "http://ec2-13-125-229-143.ap-northeast-2.compute.amazonaws.com:8080/"
 }

--- a/fe/src/pages/CocktailRegistration.tsx
+++ b/fe/src/pages/CocktailRegistration.tsx
@@ -12,6 +12,7 @@ const CocktailRegistration = () => {
   const [description, setDescription] = useState<string>("");
   const [recipeStep, setRecipeStep] = useState<string>("");
   const [selectedImage, setSelectedImage] = useState<File | null>(null);
+  const [selectLineId, setSelectLineId] = useState<number>(-1);
   const [selectLines, setSelectLines] = useState([
     { id: 0, stuff: "", amount: "", selectOption: "ml" },
   ]);
@@ -31,7 +32,8 @@ const CocktailRegistration = () => {
         data,
         {
           headers: {
-            Authorization: "Authorization Key",
+            Authorization:
+              "Bearer eyJhbGciOiJIUzUxMiJ9.eyJyb2xlcyI6WyJVU0VSIl0sInVzZXJuYW1lIjoiYXNkZkBhZGRkZGQuY29tIiwic3ViIjoiYXNkZkBhZGRkZGQuY29tIiwiaWF0IjoxNjg0MzMyMzMwLCJleHAiOjE2ODQzNTc1MzB9.Hm3iApNiC6wtpVaiAFzsG9aaJHD-efzU4ytUo8O67VPKsEljqfOkhMxAfFBWa5lJzUz1zhLhP26jqX556qT9yA",
           },
         },
       );
@@ -45,9 +47,9 @@ const CocktailRegistration = () => {
     onMutate: (variable) => {
       console.log("onMutate", variable);
     },
-    onError: (error, variable, context) => {
-      console.log(error, variable, context);
-    },
+    onError: (error) => {
+      console.log("에러발생", error);
+    }, //variable, context
     onSuccess: (data, variables, context) => {
       console.log("success", data, variables, context);
     },
@@ -66,7 +68,9 @@ const CocktailRegistration = () => {
 
   // +버튼을 누르면 재료등록폼 추가
   const handleAddSelectLine = () => {
-    const newId = selectLines.length;
+    const lastSelectLine = selectLines[selectLines.length - 1];
+    const newId = lastSelectLine.id + 1;
+
     const newSelectLines = [
       ...selectLines,
       { id: newId, stuff: "", amount: "", selectOption: "ml" },
@@ -76,21 +80,28 @@ const CocktailRegistration = () => {
 
   // X버튼을 누르면 재료등록리스트 삭제
   const handleDeleteSelectLine = (id: number) => {
+    const isCurrentSelection = id === selectLineId; // 현재 선택된 항목인지 확인
+
     const newSelectLines = selectLines.filter((line) => line.id !== id);
     setSelectLines(newSelectLines);
+
+    if (isCurrentSelection) {
+      setSelectLineId(-1);
+    }
   };
 
   const handleSubmitData = () => {
-    let totalData = "";
-    selectLines.forEach((line) => {
-      totalData += line.stuff + line.amount + line.selectOption + "\n";
-    });
+    const totalData = selectLines
+      .map((line) => {
+        return line.stuff + line.amount + line.selectOption;
+      })
+      .join("\n");
     const data = {
-      image: selectedImage,
+      // imageUrl: selectedImage,
       name: name,
       description: description,
-      recipe: recipeStep,
       ingredient: totalData,
+      recipe: recipeStep,
     };
     mutation.mutate(data);
   };

--- a/fe/src/pages/LoginPage.tsx
+++ b/fe/src/pages/LoginPage.tsx
@@ -195,7 +195,7 @@ export default function LoginPage() {
         }
       })
       .catch((error) => {
-        setError("에러가 발생하였습니다.");
+        console.error(error);
       });
   };
 


### PR DESCRIPTION
### PR 타입

-[ ] 기능 추가
-[ ] 기능 삭제
-[o] 코드 리팩토링
-[o] 버그 수정
-[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 재료목록이 담기는 totalData 메서드(join)으로 변경
- 재료목록을 선택하는 각각의 폼에 고유한 Key값을 부여

### 테스트 결과
- 서버로 전송될 data.ingredient의 마지막 개행문자 삭제
- 각각의 재료목록 폼에 고유한 key값이 부여함으로 재료폼 추가, 삭제가 반복적으로 일어났을때 key값이 충돌하는 버그 해결