### PR TITLE
Feat : Error Boundary 생성

### DIFF
--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -21,6 +21,7 @@
         "json-server": "^0.17.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-error-boundary": "^4.0.4",
         "react-icons": "^4.8.0",
         "react-proxy": "^1.1.8",
         "react-query": "^3.39.3",
@@ -15061,6 +15062,17 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-error-boundary": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.4.tgz",
+      "integrity": "sha512-AbqMFx8bCsob8rCHZvJYQ42MQijK0/034RUvan9qrqyJCpazr8d9vKHrysbxcr6odoHLZvQEcYomFPoIqH9fow==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-error-overlay": {
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
@@ -28921,6 +28933,14 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
+      }
+    },
+    "react-error-boundary": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.4.tgz",
+      "integrity": "sha512-AbqMFx8bCsob8rCHZvJYQ42MQijK0/034RUvan9qrqyJCpazr8d9vKHrysbxcr6odoHLZvQEcYomFPoIqH9fow==",
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "react-error-overlay": {

--- a/fe/package.json
+++ b/fe/package.json
@@ -16,6 +16,7 @@
     "json-server": "^0.17.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^4.0.4",
     "react-icons": "^4.8.0",
     "react-proxy": "^1.1.8",
     "react-query": "^3.39.3",

--- a/fe/src/App.tsx
+++ b/fe/src/App.tsx
@@ -20,7 +20,7 @@ function App() {
           <Route path="/" element={<Main />} />
           <Route path="/custom" element={<CustomRecipes />} />
           <Route path="/search" element={<SearchResults />} />
-          <Route path="/detail/:id" element={<DetailPage />} />
+          <Route path="/detail/:category/:id" element={<DetailPage />} />
           <Route path="/registration" element={<CocktailRegistration />} />
           <Route path="/mypage" element={<Mypage />} />
         </Route>

--- a/fe/src/components/card/Card.tsx
+++ b/fe/src/components/card/Card.tsx
@@ -5,12 +5,13 @@ interface CardProps {
   image: string;
   description: string;
   id: number;
+  category: string;
 }
-const Card = ({ name, image, description, id }: CardProps) => {
+const Card = ({ name, image, description, id, category }: CardProps) => {
   const navigate = useNavigate();
   // console.log(name, image);
   return (
-    <Container onClick={() => navigate(`/detail/${id}`)}>
+    <Container onClick={() => navigate(`/detail/${category}/${id}`)}>
       <Image url={image}>
         <HiddenText className="hidden-text">{description}</HiddenText>
       </Image>

--- a/fe/src/components/card/CardList.tsx
+++ b/fe/src/components/card/CardList.tsx
@@ -75,10 +75,6 @@ export default function CardList({ path }: ListProps) {
   const [page, setPage] = useState(1);
   const size = useMemo(() => {
     switch (path) {
-      case "10":
-        return 5;
-      case "20":
-        return 10;
       case "30":
         return 10;
       case "40":
@@ -88,12 +84,13 @@ export default function CardList({ path }: ListProps) {
     }
   }, [path]);
 
-  const { data, error, isLoading, isFetching, isPreviousData } =
+  const { data, isLoading, isFetching, isPreviousData } =
     useQuery<RegularResponseData>(
       [`${path}`, size],
       () => getCards(path, size),
       {
-        retry: 2,
+        useErrorBoundary: true,
+        retry: 0,
         staleTime: 2000,
         keepPreviousData: true,
       },
@@ -117,10 +114,6 @@ export default function CardList({ path }: ListProps) {
   const onPrevClick = () => {
     setPage((page) => (!!hasMore ? page + 1 : page));
   };
-
-  if (error) {
-    return <h2>error boundary 쓰고 싶은데.. query reset도 해보고 싶은디..</h2>;
-  }
 
   return (
     <CardsContainer>

--- a/fe/src/components/card/CardList.tsx
+++ b/fe/src/components/card/CardList.tsx
@@ -93,6 +93,7 @@ export default function CardList({ path }: ListProps) {
       [`${path}`, size],
       () => getCards(path, size),
       {
+        retry: 2,
         staleTime: 2000,
         keepPreviousData: true,
       },
@@ -143,6 +144,7 @@ export default function CardList({ path }: ListProps) {
                 description={recipe.description}
                 id={recipe.id}
                 key={i}
+                category="regular"
               />
             );
           })}

--- a/fe/src/components/errorFallback/CardListFallback.tsx
+++ b/fe/src/components/errorFallback/CardListFallback.tsx
@@ -1,0 +1,51 @@
+import styled from "styled-components";
+
+const ErrorFallbackContainer = styled.div`
+  width: 100%;
+  height: 100%;
+  padding: 10px 0;
+  border-top: 1px solid gray;
+  border-bottom: 1px solid gray;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+const ErrorDisplay = styled.div`
+  text-align: center;
+`;
+
+const ErrorMessage = styled.p`
+  font-size: 1.3rem;
+  font-weight: bold;
+  margin-bottom: 10px;
+`;
+
+const ResetButton = styled.button`
+  color: white;
+  font-weight: bold;
+  border: none;
+  background-color: #96a5ff;
+  padding: 5px;
+  border-radius: 5px;
+  margin: 10px auto;
+`;
+
+export default function CardListFallback({
+  error,
+  resetErrorBoundary,
+}: {
+  error: Error;
+  resetErrorBoundary: () => void;
+}) {
+  return (
+    <ErrorFallbackContainer>
+      <ErrorDisplay>
+        <ErrorMessage>레시피 불러오기를 실패했습니다.</ErrorMessage>
+        <p>잠시 후 다시 시도해 주세요</p>
+      </ErrorDisplay>
+      <ResetButton onClick={() => resetErrorBoundary()}>새로고침</ResetButton>
+    </ErrorFallbackContainer>
+  );
+}

--- a/fe/src/pages/CustomRecipes.tsx
+++ b/fe/src/pages/CustomRecipes.tsx
@@ -62,6 +62,7 @@ export default function CustomRecipes() {
               image={recipe.imageUrl}
               description={recipe.description}
               id={recipe.id}
+              category="custom"
             />
           );
         })}

--- a/fe/src/pages/Main.tsx
+++ b/fe/src/pages/Main.tsx
@@ -1,6 +1,9 @@
 import styled from "styled-components";
 import CardList from "../components/card/CardList";
 import { useMemo } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import CardListFallback from "../components/errorFallback/CardListFallback";
+import { useQueryErrorResetBoundary } from "react-query";
 
 export const RecipesContainer = styled.div`
   min-height: 100vh;
@@ -19,6 +22,7 @@ const GuideText = styled.div`
 `;
 
 export default function Main() {
+  const { reset } = useQueryErrorResetBoundary();
   const alclholLevel = useMemo(() => {
     return ["0", "10", "20", "30", "40"];
   }, []);
@@ -27,7 +31,13 @@ export default function Main() {
       <RecipesContainer>
         <GuideText>정규 레시피</GuideText>
         {alclholLevel.map((alcohol, i) => (
-          <CardList path={alcohol} key={i} />
+          <ErrorBoundary
+            key={i}
+            FallbackComponent={CardListFallback}
+            onReset={reset}
+          >
+            <CardList path={alcohol} key={i} />
+          </ErrorBoundary>
         ))}
       </RecipesContainer>
     </>

--- a/fe/src/utils/query.ts
+++ b/fe/src/utils/query.ts
@@ -23,9 +23,9 @@ export interface RegularResponseData {
   pageInfo: PageInfo;
 }
 
-export const getCards = async (path: string, size: number, page = 1) => {
+export const getCards = async (alcohol: string, size: number, page = 1) => {
   const response: AxiosResponse<{ data: RegularResponseData }> =
-    await axios.get(`/regular/findAll/${path}?page=${page}&size=${size}`);
+    await axios.get(`/regular/findAll/${alcohol}?page=${page}&size=${size}`);
   return response.data.data;
 };
 


### PR DESCRIPTION
### PR 타입

-[o] 기능 추가
-[ ] 기능 삭제
-[ ] 코드 리팩토링
-[ ] 버그 수정
-[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 메인 페이지 알코올 도수별 error boundary 적용
- query reset 으로 data 새로고침
- query.ts의 path => alcohol 변수명 변경
### 테스트 결과
- 알코올 레벨의 get 요청에서 오류가 났을 경우 각 요청을 reset할수 있는 버튼 등장
- 오류가 났을 경우 관련 메세지 등장