### PR TITLE
Fix: 커스텀레시피의 정보를 조회했을때 정규레시피 정보가 보이는 버그수정

### DIFF
--- a/fe/src/hooks/useFetchRecipe.tsx
+++ b/fe/src/hooks/useFetchRecipe.tsx
@@ -1,26 +1,30 @@
 import { useQuery } from "react-query";
 import axios from "axios";
-// import { RecipeData } from "../utils/query";
+import { useNavigate } from "react-router-dom";
 
 export interface RecipeData {
   data: {
     id: number;
-    name: string;
     imageUrl: string;
-    description: string;
     ingredient: string;
+    name: string;
     recipe: string;
+    description: string;
   };
 }
 
-const fetchRecipe = async (params: string) => {
-  const response = await axios.get(`/regular/find/${params}`);
+const fetchRecipe = async (category: string, id: string) => {
+  const response = await axios.get(`/${category}/find/${id}`);
   return response.data;
 };
 
-export const useFetchRecipe = (id: string) => {
+export const useFetchRecipe = (category: string, id: string) => {
+  const navigate = useNavigate();
+  if (category === "" && id === "") {
+    navigate("/error");
+  }
   const { data, isLoading, error } = useQuery<RecipeData>(["recipe", id], () =>
-    fetchRecipe(id),
+    fetchRecipe(category, id),
   );
   return { data, isLoading, error };
 };

--- a/fe/src/pages/CocktailRegistration.tsx
+++ b/fe/src/pages/CocktailRegistration.tsx
@@ -2,7 +2,6 @@ import styled from "styled-components";
 import { AiOutlinePlus, AiFillPlusCircle } from "react-icons/ai";
 import { TiDelete } from "react-icons/ti";
 import React, { useState } from "react";
-import axios from "axios";
 import { useMutation } from "react-query";
 import ImageUpload from "../components/imageupload/ImageUpload";
 import { useNavigate } from "react-router-dom";
@@ -120,7 +119,7 @@ const CocktailRegistration = () => {
         imageMutation.mutate(input, {
           onSuccess: (data) => {
             console.log(data);
-            // navigate("/custom");
+            navigate("/custom");
           },
         });
       },

--- a/fe/src/pages/CustomRecipes.tsx
+++ b/fe/src/pages/CustomRecipes.tsx
@@ -49,7 +49,9 @@ export default function CustomRecipes() {
     <RecipesContainer>
       <CustomGuide>
         <GuideText>커스텀 레시피</GuideText>
-        <RegistrationLink to={"/upload"}>레시피 등록하기</RegistrationLink>
+        <RegistrationLink to={"/registration"}>
+          레시피 등록하기
+        </RegistrationLink>
       </CustomGuide>
       <CardsRow>
         {isLoading && <LoadingComponent />}

--- a/fe/src/pages/DetailPage.tsx
+++ b/fe/src/pages/DetailPage.tsx
@@ -5,11 +5,13 @@ import { useFetchRecipe } from "../hooks/useFetchRecipe";
 
 export default function DetailPage() {
   const navigate = useNavigate();
-  const { id } = useParams();
-  const { data, isLoading, error } = useFetchRecipe(id || "");
-  if (isLoading) return <div>Loading...</div>;
+  const { category, id } = useParams();
+
+  const { data, isLoading, error } = useFetchRecipe(category || "", id || "");
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
   if (error) {
-    // errorBoundary로 수정 예정?
     console.error(error);
     navigate("/Error");
   }

--- a/fe/src/pages/Mypage.tsx
+++ b/fe/src/pages/Mypage.tsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import MenuBar from "../components/myPage/MenuBar";
 // import EditMyInfo from "../components/myPage/EditMyInfo";
 import MyInfo from "../components/myPage/MyInfo";
-import MyRecipes from "../components/myPage/MyRecipes";
+// import MyRecipes from "../components/myPage/MyRecipes";
 import { useState } from "react";
 
 const Container = styled.div`
@@ -22,7 +22,7 @@ export default function Mypage() {
       <MenuBar page={page} setPage={setPage} />
       {page === "myInfo" && <MyInfo />}
       {page === "bookMark" && <MyInfo />}
-      {page === "myRecipe" && <MyRecipes />}
+      {/* {page === "myRecipe" && <MyRecipes />} */}
     </Container>
   );
 }


### PR DESCRIPTION
### PR 타입

-[ ] 기능 추가
-[ ] 기능 삭제
-[o] 코드 리팩토링
-[o] 버그 수정
-[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 커스텀레시피 조회 창에서 커스텀레시피 카드를 눌렀을 경우 커스텀 레시피에 대한 정보가 나타남.

### 테스트 결과
- 커스텀레시피 조회 창에서 커스텀레시피 카드를 눌렀을 때 정규레시피 정보가 나오지 
  않고 해당 커스텀레시피 정보가 올바르게 나오도록 수정.
