### PR TITLE
Fix : 검색 결과 페이지 검색어 변경시 페이지 번호가 초기화 되지 않는 버그

### DIFF
--- a/fe/src/App.tsx
+++ b/fe/src/App.tsx
@@ -25,7 +25,6 @@ function App() {
           <Route path="/registration" element={<CocktailRegistration />} />
           <Route path="/custom/edit/:id" element={<CocktailEdit />} />
           <Route path="/mypage" element={<Mypage />} />
-          <Route path="/customedit" element={<CocktailEdit />} />
           <Route path="/custom/edit/:id" element={<CocktailEdit />} />
         </Route>
         <Route path="/signup" element={<SignUp />} />

--- a/fe/src/hooks/useSearchedPagination.ts
+++ b/fe/src/hooks/useSearchedPagination.ts
@@ -2,16 +2,25 @@ import { SearchResponse, getSearchResults } from "../utils/query";
 import { useQuery, useQueryClient } from "react-query";
 import { useState, useEffect } from "react";
 
-export function useSearchedPagination(path: string, searchValue: string) {
-  const [page, setPage] = useState(1);
+export function useSearchedPagination(
+  path: string,
+  searchValue: string,
+  initPage: number,
+) {
+  const [page, setPage] = useState(initPage);
+  const [searchState, setSearchState] = useState(searchValue);
   const queryClient = useQueryClient();
+  if (searchState !== searchValue) {
+    setPage(1);
+    setSearchState(searchValue);
+  }
   const { data, isFetching, isLoading, isPreviousData } =
     useQuery<SearchResponse>(
-      [`${path}`, searchValue],
-      () => getSearchResults(path, searchValue),
+      [path],
+      () => getSearchResults(path, searchState),
       {
+        retry: 0,
         staleTime: 2000,
-        keepPreviousData: true,
       },
     );
 
@@ -26,10 +35,10 @@ export function useSearchedPagination(path: string, searchValue: string) {
   };
 
   useEffect(() => {
-    getSearchResults(path, searchValue, page).then((responseData) => {
-      queryClient.setQueryData([`${path}`, searchValue], responseData);
+    getSearchResults(path, searchState, page).then((responseData) => {
+      queryClient.setQueryData([path], responseData);
     });
-  }, [path, searchValue, page, queryClient]);
+  }, [searchState, page, queryClient]);
 
   return {
     data,

--- a/fe/src/hooks/useSearchedPagination.ts
+++ b/fe/src/hooks/useSearchedPagination.ts
@@ -2,12 +2,8 @@ import { SearchResponse, getSearchResults } from "../utils/query";
 import { useQuery, useQueryClient } from "react-query";
 import { useState, useEffect } from "react";
 
-export function useSearchedPagination(
-  path: string,
-  searchValue: string,
-  initPage: number,
-) {
-  const [page, setPage] = useState(initPage);
+export function useSearchedPagination(path: string, searchValue: string) {
+  const [page, setPage] = useState(1);
   const [searchState, setSearchState] = useState(searchValue);
   const queryClient = useQueryClient();
   if (searchState !== searchValue) {

--- a/fe/src/pages/SearchResults.tsx
+++ b/fe/src/pages/SearchResults.tsx
@@ -2,11 +2,12 @@ import { RecipesContainer } from "./Main";
 import { useSearchParams } from "react-router-dom";
 import SearchResultTab from "../components/card/SearchResultsTab";
 import styled from "styled-components";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import SearchedRecipe from "../components/card/SearchedRecipe";
 import RecipePagination from "../components/card/RecipePagination";
 import { useSearchedPagination } from "../hooks/useSearchedPagination";
 import LoadingComponent from "../components/loading/LoadingComponent";
+import { useQueryClient } from "react-query";
 
 const CardListArea = styled.div`
   margin: 30px 0;
@@ -18,23 +19,28 @@ const CardListArea = styled.div`
 `;
 
 export default function SearchResults() {
+  const queryClient = useQueryClient();
   const [searchParams, setSearchParams] = useSearchParams();
   const searchValue = searchParams.get("value") ?? "";
   const category = useMemo(() => ["regular", "custom"], []);
   const [path, setPath] = useState(category[0]);
+  useEffect(() => {
+    queryClient.clear();
+  }, []);
   const { data, isLoading, isPreviousData, hasMore, onNextClick, onPrevClick } =
-    useSearchedPagination(path, searchValue);
+    useSearchedPagination(path, searchValue, 1);
 
   return (
     <RecipesContainer>
       <SearchResultTab tabs={category} path={path} setPath={setPath} />
       {isLoading && <LoadingComponent />}
       <CardListArea>
-        {data?.data.map((card, i) => {
-          return <SearchedRecipe key={i} recipe={card} category={path} />;
-        })}
+        {!isLoading &&
+          data?.data.map((card, i) => {
+            return <SearchedRecipe key={i} recipe={card} category={path} />;
+          })}
       </CardListArea>
-      {data?.pageInfo && data.pageInfo.totalPage > 1 && (
+      {!isLoading && data?.pageInfo && data.pageInfo.totalPage > 1 && (
         <RecipePagination
           pageInfo={data?.pageInfo}
           hasMore={!!hasMore}

--- a/fe/src/pages/SearchResults.tsx
+++ b/fe/src/pages/SearchResults.tsx
@@ -28,7 +28,7 @@ export default function SearchResults() {
     queryClient.clear();
   }, []);
   const { data, isLoading, isPreviousData, hasMore, onNextClick, onPrevClick } =
-    useSearchedPagination(path, searchValue, 1);
+    useSearchedPagination(path, searchValue);
 
   return (
     <RecipesContainer>


### PR DESCRIPTION
### PR 타입

-[ ] 기능 추가
-[ ] 기능 삭제
-[ ] 코드 리팩토링
-[o] 버그 수정
-[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 검색 페이지 네이션 훅 내에 새로운 훅 searchState(이전 검색어) 생성
- 검색 결과 페이지 useEffect 추가
- query key 변경

### 테스트 결과
- 검색 결과가 달라지면 페이지가 1로 변경
- 다른 페이지로 이동 했다가 검색했을 시 기존 캐싱 데이터로 인해 이전 검색 결과가 0.5초 정도 나타나는 현상이 삭제됨
